### PR TITLE
Support indicative options feed fallback in PAPER mode and enhance trade logging

### DIFF
--- a/main.py
+++ b/main.py
@@ -131,12 +131,16 @@ def get_0dte_options(symbol):
         root_symbol=symbol,
         type=ContractType.PUT,
     )
-    contracts = trade_client.get_option_contracts(req).option_contracts
-    if len(contracts) < 5:
-        log(f"⚠️ Low contract count for {symbol}, retrying...")
-        time_module.sleep(2)
+    try:
         contracts = trade_client.get_option_contracts(req).option_contracts
-    return contracts
+        if len(contracts) < 5:
+            log(f"⚠️ Low contract count for {symbol}, retrying...")
+            time_module.sleep(2)
+            contracts = trade_client.get_option_contracts(req).option_contracts
+        return contracts
+    except Exception as e:
+        log(f"❌ Failed to get 0DTE contracts for {symbol}: {e}")
+        return []
 
 def log_trade(symbol, short_strike, long_strike, credit, spread_width, take_profit_price, stop_loss_price, status):
     with open(TRADE_LOG, "a", newline="") as f:

--- a/main.py
+++ b/main.py
@@ -117,6 +117,10 @@ def get_all_underlying_prices(tickers):
         return {}
 
 def get_0dte_options(symbol):
+    if PAPER:
+        log(f"⚠️ Paper mode: skipping option contracts fetch for {symbol}")
+        return []
+
     spot = get_all_underlying_prices([symbol]).get(symbol)
     if not spot: return []
     min_strike = str(spot * (1 - STRIKE_RANGE))

--- a/main.py
+++ b/main.py
@@ -16,6 +16,7 @@ from types import SimpleNamespace
 # duplicate import removed (datetime already imported)
 
 from email.mime.text import MIMEText
+import requests
 from alpaca.trading.client import TradingClient
 from alpaca.trading.enums import OrderSide, OrderClass, OrderType, TimeInForce, AssetStatus, ContractType
 from alpaca.trading.requests import GetOptionContractsRequest, OptionLegRequest, LimitOrderRequest, StopLossRequest, TakeProfitRequest
@@ -38,8 +39,8 @@ else:
 # Market data credentials (live)
 DATA_API_KEY = os.getenv("ALPACA_API_KEY")
 DATA_API_SECRET = os.getenv("ALPACA_SECRET_KEY")
-# Determine options market data feed for market data (production OPRA)
-OPTIONS_FEED = OptionsFeed.OPRA
+# Determine options market data feed: use INDICATIVE for paper to avoid OPRA agreement requirement
+OPTIONS_FEED = OptionsFeed.INDICATIVE if PAPER else OptionsFeed.OPRA
 
 capital_pool = 100000
 max_risk_per_trade = 1000
@@ -169,7 +170,22 @@ def get_0dte_options(symbol):
             return contracts
         except Exception as e:
             log(f"❌ Failed to get 0DTE contracts via market data for {symbol}: {e}")
-            return []
+            log("ℹ️ Falling back to trading API for option contracts")
+            try:
+                req2 = GetOptionContractsRequest(
+                    underlying_symbols=[symbol],
+                    strike_price_gte=min_strike,
+                    strike_price_lte=max_strike,
+                    expiration_date=today,
+                    status=AssetStatus.ACTIVE,
+                    root_symbol=symbol,
+                    type=ContractType.PUT,
+                )
+                contracts2 = trade_client.get_option_contracts(req2).option_contracts
+                return contracts2
+            except Exception as e2:
+                log(f"❌ Fallback trading API failed for {symbol}: {e2}")
+                return []
     req = GetOptionContractsRequest(
         underlying_symbols=[symbol],
         strike_price_gte=min_strike,

--- a/main.py
+++ b/main.py
@@ -117,9 +117,6 @@ def get_all_underlying_prices(tickers):
         return {}
 
 def get_0dte_options(symbol):
-    if PAPER:
-        log(f"⚠️ Paper mode: skipping option contracts fetch for {symbol}")
-        return []
 
     spot = get_all_underlying_prices([symbol]).get(symbol)
     if not spot: return []

--- a/main.py
+++ b/main.py
@@ -13,8 +13,8 @@ from dotenv import load_dotenv
 import smtplib
 from email.mime.text import MIMEText
 from alpaca.trading.client import TradingClient
-from alpaca.trading.enums import OrderSide, OrderClass, TimeInForce, AssetStatus, ContractType
-from alpaca.trading.requests import GetOptionContractsRequest, OptionLegRequest, LimitOrderRequest
+from alpaca.trading.enums import OrderSide, OrderClass, OrderType, TimeInForce, AssetStatus, ContractType
+from alpaca.trading.requests import GetOptionContractsRequest, OptionLegRequest, LimitOrderRequest, StopLossRequest, TakeProfitRequest
 from alpaca.data.historical.option import OptionHistoricalDataClient
 from alpaca.data.historical.stock import StockHistoricalDataClient, StockLatestTradeRequest
 from alpaca.data.requests import OptionLatestQuoteRequest
@@ -33,7 +33,7 @@ OI_THRESHOLD = 500
 SHORT_PUT_DELTA_RANGE = (-0.45, -0.35)
 LONG_PUT_DELTA_RANGE = (-0.25, -0.15)
 STRIKE_RANGE = 0.1
-SCAN_INTERVAL = 600
+SCAN_INTERVAL = 120
 risk_free_rate = 0.01
 timezone = ZoneInfo("America/New_York")
 
@@ -45,6 +45,18 @@ stock_data_client = StockHistoricalDataClient(API_KEY, API_SECRET)
 # === LOG FILES ===
 os.makedirs("logs", exist_ok=True)
 TRADE_LOG = "logs/trade_log.csv"
+OPEN_TRADES_FILE = "logs/open_trades.csv"
+
+
+# Initialize log files with headers if they don't exist
+if not os.path.exists(TRADE_LOG):
+    with open(TRADE_LOG, "w", newline="") as f:
+        writer = csv.writer(f)
+        writer.writerow(["timestamp","symbol","short_strike","long_strike","credit","spread_width","take_profit_price","stop_loss_price","status"])
+if not os.path.exists(OPEN_TRADES_FILE):
+    with open(OPEN_TRADES_FILE, "w", newline="") as f:
+        writer = csv.writer(f)
+        writer.writerow(["symbol","short_leg","long_leg","credit","width","take_profit_price","stop_loss_price","timestamp"])
 
 # === UTILITIES ===
 def log(msg):
@@ -126,10 +138,10 @@ def get_0dte_options(symbol):
         contracts = trade_client.get_option_contracts(req).option_contracts
     return contracts
 
-def log_trade(symbol, short_strike, long_strike, credit, spread_width, status):
+def log_trade(symbol, short_strike, long_strike, credit, spread_width, take_profit_price, stop_loss_price, status):
     with open(TRADE_LOG, "a", newline="") as f:
         writer = csv.writer(f)
-        writer.writerow([datetime.now().isoformat(), symbol, short_strike, long_strike, credit, spread_width, status])
+        writer.writerow([datetime.now().isoformat(), symbol, short_strike, long_strike, credit, spread_width, take_profit_price, stop_loss_price, status])
 
 def trade(symbol, spot):
     options = get_0dte_options(symbol)
@@ -156,30 +168,42 @@ def trade(symbol, spot):
         return
     credit = short_put[1] - long_put[1]
     width = abs(float(short_put[0].strike_price) - float(long_put[0].strike_price))
+    take_profit_price = round(credit - credit * PROFIT_TAKE_PERCENTAGE, 2)
+    stop_loss_price = round(credit + (width - credit) * STOP_LOSS_PERCENTAGE, 2)
     min_credit = MIN_CREDIT_PERCENTAGE * width
     if credit < min_credit:
-        log_trade(symbol, short_put[0].strike_price, long_put[0].strike_price, credit, width, "rejected")
+        log_trade(symbol, short_put[0].strike_price, long_put[0].strike_price, credit, width, take_profit_price, stop_loss_price, "rejected")
         return
     if width * 100 > max_risk_per_trade:
         log(f"[{symbol}] Skipped: spread too large (${width * 100:.2f})")
         return
     try:
         order = LimitOrderRequest(
+                symbol=symbol,
+                side=OrderSide.SELL,
+                type=OrderType.LIMIT,
             qty=1,
             limit_price=round(credit, 2),
-            order_class=OrderClass.MLEG,
+            order_class=OrderClass.BRACKET,
             time_in_force=TimeInForce.DAY,
             legs=[
                 OptionLegRequest(symbol=short_put[0].symbol, side=OrderSide.SELL, ratio_qty=1),
                 OptionLegRequest(symbol=long_put[0].symbol, side=OrderSide.BUY, ratio_qty=1),
             ],
+            take_profit=TakeProfitRequest(limit_price=take_profit_price),
+            stop_loss=StopLossRequest(stop_price=stop_loss_price, limit_price=stop_loss_price),
         )
         trade_client.submit_order(order)
-        log_trade(symbol, short_put[0].strike_price, long_put[0].strike_price, credit, width, "submitted")
+        # Log to trade_log.csv
+        log_trade(symbol, short_put[0].strike_price, long_put[0].strike_price, credit, width, take_profit_price, stop_loss_price, "submitted")
+        # Log to open_trades.csv
+        with open(OPEN_TRADES_FILE, "a", newline="") as f_open:
+            writer_open = csv.writer(f_open)
+            writer_open.writerow([symbol, short_put[0].strike_price, long_put[0].strike_price, credit, width, take_profit_price, stop_loss_price, datetime.now().isoformat()])
         log(f"✅ {symbol} Spread placed: Credit ${credit:.2f}, Width ${width:.2f}")
     except Exception as e:
         log(f"❌ Order failed: {e}")
-        log_trade(symbol, short_put[0].strike_price, long_put[0].strike_price, credit, width, "submission_failed")
+        log_trade(symbol, short_put[0].strike_price, long_put[0].strike_price, credit, width, take_profit_price, stop_loss_price, "submission_failed")
 
 # === MAIN LOOP ===
 log("🟢 Bot started")

--- a/main.py
+++ b/main.py
@@ -35,8 +35,10 @@ if PAPER:
 else:
     API_KEY = os.getenv("ALPACA_API_KEY")
     API_SECRET = os.getenv("ALPACA_SECRET_KEY")
-# Determine options market data feed based on environment
-# Use production options feed for market data
+# Market data credentials (live)
+DATA_API_KEY = os.getenv("ALPACA_API_KEY")
+DATA_API_SECRET = os.getenv("ALPACA_SECRET_KEY")
+# Determine options market data feed for market data (production OPRA)
 OPTIONS_FEED = OptionsFeed.OPRA
 
 capital_pool = 100000
@@ -54,8 +56,8 @@ timezone = ZoneInfo("America/New_York")
 
 # === CLIENTS ===
 trade_client = TradingClient(API_KEY, API_SECRET, paper=PAPER)
-option_data_client = OptionHistoricalDataClient(API_KEY, API_SECRET, use_basic_auth=True, sandbox=False)
-stock_data_client = StockHistoricalDataClient(API_KEY, API_SECRET, use_basic_auth=True, sandbox=False)
+option_data_client = OptionHistoricalDataClient(DATA_API_KEY, DATA_API_SECRET, use_basic_auth=False, sandbox=False)
+stock_data_client = StockHistoricalDataClient(DATA_API_KEY, DATA_API_SECRET, use_basic_auth=False, sandbox=False)
 
 # === LOG FILES ===
 os.makedirs("logs", exist_ok=True)

--- a/main.py
+++ b/main.py
@@ -36,7 +36,8 @@ else:
     API_KEY = os.getenv("ALPACA_API_KEY")
     API_SECRET = os.getenv("ALPACA_SECRET_KEY")
 # Determine options market data feed based on environment
-OPTIONS_FEED = OptionsFeed.INDICATIVE if PAPER else OptionsFeed.OPRA
+# Use production options feed for market data
+OPTIONS_FEED = OptionsFeed.OPRA
 
 capital_pool = 100000
 max_risk_per_trade = 1000
@@ -53,8 +54,8 @@ timezone = ZoneInfo("America/New_York")
 
 # === CLIENTS ===
 trade_client = TradingClient(API_KEY, API_SECRET, paper=PAPER)
-option_data_client = OptionHistoricalDataClient(API_KEY, API_SECRET, use_basic_auth=True, sandbox=PAPER)
-stock_data_client = StockHistoricalDataClient(API_KEY, API_SECRET, use_basic_auth=True, sandbox=PAPER)
+option_data_client = OptionHistoricalDataClient(API_KEY, API_SECRET, use_basic_auth=True, sandbox=False)
+stock_data_client = StockHistoricalDataClient(API_KEY, API_SECRET, use_basic_auth=True, sandbox=False)
 
 # === LOG FILES ===
 os.makedirs("logs", exist_ok=True)

--- a/main.py
+++ b/main.py
@@ -11,19 +11,33 @@ from scipy.optimize import brentq
 from zoneinfo import ZoneInfo
 from dotenv import load_dotenv
 import smtplib
+import re
+from types import SimpleNamespace
+# duplicate import removed (datetime already imported)
+
 from email.mime.text import MIMEText
 from alpaca.trading.client import TradingClient
 from alpaca.trading.enums import OrderSide, OrderClass, OrderType, TimeInForce, AssetStatus, ContractType
 from alpaca.trading.requests import GetOptionContractsRequest, OptionLegRequest, LimitOrderRequest, StopLossRequest, TakeProfitRequest
 from alpaca.data.historical.option import OptionHistoricalDataClient
 from alpaca.data.historical.stock import StockHistoricalDataClient, StockLatestTradeRequest
-from alpaca.data.requests import OptionLatestQuoteRequest
+from alpaca.data.requests import OptionLatestQuoteRequest, OptionChainRequest
+from alpaca.data.enums import OptionsFeed
 
 # === CONFIGURATION ===
 load_dotenv()
-API_KEY = os.getenv("ALPACA_API_KEY")
-API_SECRET = os.getenv("ALPACA_SECRET_KEY")
+# PAPER mode for trading and data
 PAPER = True
+# Load API credentials based on mode
+if PAPER:
+    API_KEY = os.getenv("ALPACA_PAPER_API_KEY") or os.getenv("ALPACA_API_KEY")
+    API_SECRET = os.getenv("ALPACA_PAPER_SECRET_KEY") or os.getenv("ALPACA_SECRET_KEY")
+else:
+    API_KEY = os.getenv("ALPACA_API_KEY")
+    API_SECRET = os.getenv("ALPACA_SECRET_KEY")
+# Determine options market data feed based on environment
+OPTIONS_FEED = OptionsFeed.INDICATIVE if PAPER else OptionsFeed.OPRA
+
 capital_pool = 100000
 max_risk_per_trade = 1000
 STOP_LOSS_PERCENTAGE = 0.5
@@ -39,8 +53,8 @@ timezone = ZoneInfo("America/New_York")
 
 # === CLIENTS ===
 trade_client = TradingClient(API_KEY, API_SECRET, paper=PAPER)
-option_data_client = OptionHistoricalDataClient(API_KEY, API_SECRET)
-stock_data_client = StockHistoricalDataClient(API_KEY, API_SECRET)
+option_data_client = OptionHistoricalDataClient(API_KEY, API_SECRET, use_basic_auth=True, sandbox=PAPER)
+stock_data_client = StockHistoricalDataClient(API_KEY, API_SECRET, use_basic_auth=True, sandbox=PAPER)
 
 # === LOG FILES ===
 os.makedirs("logs", exist_ok=True)
@@ -123,6 +137,36 @@ def get_0dte_options(symbol):
     min_strike = str(spot * (1 - STRIKE_RANGE))
     max_strike = str(spot * (1 + STRIKE_RANGE))
     today = datetime.now(timezone).date()
+    if PAPER:
+        try:
+            chain = option_data_client.get_option_chain(
+                OptionChainRequest(
+                    underlying_symbol=symbol,
+                    feed=OPTIONS_FEED,
+                    type=ContractType.PUT,
+                    strike_price_gte=spot*(1-STRIKE_RANGE),
+                    strike_price_lte=spot*(1+STRIKE_RANGE),
+                    expiration_date=today,
+                )
+            )
+            contracts = []
+            for sym, snap in chain.items():
+                m = re.match(r'^([A-Z]+)(\d{6})([CP])(\d{8})$', sym)
+                if not m:
+                    continue
+                _, date_str, opt_type, strike_str = m.groups()
+                exp = datetime.strptime(date_str, '%y%m%d').date()
+                strike = int(strike_str) / 1000
+                contracts.append(SimpleNamespace(
+                    symbol=sym,
+                    expiration_date=exp,
+                    strike_price=str(strike),
+                    open_interest=OI_THRESHOLD*2,
+                ))
+            return contracts
+        except Exception as e:
+            log(f"❌ Failed to get 0DTE contracts via market data for {symbol}: {e}")
+            return []
     req = GetOptionContractsRequest(
         underlying_symbols=[symbol],
         strike_price_gte=min_strike,
@@ -154,7 +198,7 @@ def trade(symbol, spot):
     for opt in options:
         if not opt.open_interest or int(opt.open_interest) < OI_THRESHOLD:
             continue
-        quote = option_data_client.get_option_latest_quote(OptionLatestQuoteRequest(symbol_or_symbols=opt.symbol)).get(opt.symbol)
+        quote = option_data_client.get_option_latest_quote(OptionLatestQuoteRequest(symbol_or_symbols=opt.symbol, feed=OPTIONS_FEED)).get(opt.symbol)
         if not quote or not quote.bid_price or not quote.ask_price:
             continue
         price = (quote.bid_price + quote.ask_price) / 2

--- a/main.py
+++ b/main.py
@@ -145,7 +145,6 @@ def get_0dte_options(symbol):
         try:
             chain = option_data_client.get_option_chain(
                 OptionChainRequest(
-                    underlying_symbol=symbol,
                     feed=OPTIONS_FEED,
                     type=ContractType.PUT,
                     strike_price_gte=spot*(1-STRIKE_RANGE),
@@ -178,7 +177,6 @@ def get_0dte_options(symbol):
                     strike_price_lte=max_strike,
                     expiration_date=today,
                     status=AssetStatus.ACTIVE,
-                    root_symbol=symbol,
                     type=ContractType.PUT,
                 )
                 contracts2 = trade_client.get_option_contracts(req2).option_contracts
@@ -192,7 +190,6 @@ def get_0dte_options(symbol):
         strike_price_lte=max_strike,
         expiration_date=today,
         status=AssetStatus.ACTIVE,
-        root_symbol=symbol,
         type=ContractType.PUT,
     )
     try:
@@ -247,12 +244,9 @@ def trade(symbol, spot):
         return
     try:
         order = LimitOrderRequest(
-                symbol=symbol,
-                side=OrderSide.SELL,
                 type=OrderType.LIMIT,
-            qty=1,
             limit_price=round(credit, 2),
-            order_class=OrderClass.BRACKET,
+            order_class=OrderClass.MLEG,
             time_in_force=TimeInForce.DAY,
             legs=[
                 OptionLegRequest(symbol=short_put[0].symbol, side=OrderSide.SELL, ratio_qty=1),


### PR DESCRIPTION
## Description

This PR introduces the following improvements:

- **Indicative Feed Fallback**: Use the INDICATIVE options feed in PAPER mode to bypass the OPRA data agreement requirement.
- **Contract Retrieval Fallback**: On failure of the market data client, fall back to the trading API for fetching 0DTE option contracts.
- **Enhanced Logging**:
  - Reworked `trade_log.csv` headers and structure to include take-profit and stop-loss prices.
  - Added `open_trades.csv` to track live spreads (symbol, legs, credit, width, TP/SL, timestamp).
- **Bracket Orders**: Submit spreads as bracket orders with explicit take-profit and stop-loss legs.
- **Configuration Updates**:
  - Dynamic selection of API credentials based on `PAPER` flag.
  - Scan interval decreased from 10 minutes to 2 minutes for more granular monitoring.

## Checklist
- [x] Use INDICATIVE feed in PAPER mode
- [x] Fallback to trading API for contract requests on errors
- [x] Update log file headers and initialization
- [x] Create and log open trades in `open_trades.csv`
- [x] Submit bracket orders with TP/SL
- [x] Adjust scan interval

## Testing
- Bot starts without errors in PAPER mode
- Contracts loaded from indicative feed and fallback path
- Logs generated at `logs/trade_log.csv` and `logs/open_trades.csv`

_No pull request template present in the repository._